### PR TITLE
Adds batch processing feature

### DIFF
--- a/aligner.py
+++ b/aligner.py
@@ -1,15 +1,41 @@
 # imports
-import os, argparse
+import argparse
+from typing import Optional, Literal
+
 from utils import align_notes_labels_audio
+
+
 # from ms3 import check_dir
 
 
+def main(
+        audio_path: str,
+        notes_path: str,
+        labels_path: Optional[str] = None,
+        store: bool = True,
+        store_path: Optional[str] = None,
+        verbose: bool = False,
+        visualize: bool = False,
+        evaluate: bool = False,
+        mode: Literal['compact', 'labels', 'extended'] = 'compact'
+):
+    align_notes_labels_audio(
+        audio_path=audio_path,
+        notes_path=notes_path,
+        labels_path=labels_path,
+        store=store,
+        store_path=store_path,
+        verbose=verbose,
+        visualize=visualize,
+        evaluate=evaluate,
+        mode=mode
+    )
 
-def main():
-    """ Audio-to-annotations aligner """
-    
+
+def parse_args():
     # define parser
-    parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter, description="""
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter, description="""
     
     This script performs the alignment between an audio recording of a piece present in DCML Mozart sonatas 
     corpus [1], using synctoolbox dynamic time warping (DTW) tools [2]. 
@@ -41,34 +67,44 @@ def main():
         Journal of Open Source Software (JOSS), 6(64), 2021.
         [https://github.com/meinardmueller/synctoolbox]
         
-    """)
-    
+    """
+    )
     parser.add_argument('-a', '--audio', help='Path to audiofile', required=True)
-    #parser.add_argument('-p','--piece', help='Name of the desired piece from the Mozart corpus')
+    # parser.add_argument('-p','--piece', help='Name of the desired piece from the Mozart corpus')
     parser.add_argument('-n', '--notes', help='Path to the notes TSV file', required=True)
     parser.add_argument('-l', '--labels', help='Path to the labels TSV file', required=False)
-    #parser.add_argument('-o', '--output', type=check_dir, default=os.path.join(os.getcwd(), 'alignment'), help='Folder for storing the alignment result. Can be relative, defaults to ./alignment')
-    parser.add_argument('-o', '--output', help='Folder for storing the alignment result. Can be relative, defaults to current working directory.')
-    parser.add_argument('-m', '--mode', help="Output format mode, to choose between ['compact', 'labels', 'extended', 'scofo']. default: ", default='compact')
-    parser.add_argument('-e', '--evaluate', help="Evaluate warping mode. default: False", action='store_true', default=False)
-
-    
+    # parser.add_argument('-o', '--output', type=check_dir, default=os.path.join(os.getcwd(), 'alignment'),
+    # help='Folder for storing the alignment result. Can be relative, defaults to ./alignment')
+    parser.add_argument(
+        '-o', '--output',
+        help='Folder for storing the alignment result. Can be relative, defaults to current working directory.'
+    )
+    parser.add_argument(
+        '-m', '--mode',
+        help="Output format mode, to choose between ['compact', 'labels', 'extended', 'scofo']. default: ",
+        default='compact'
+    )
+    parser.add_argument(
+        '-e', '--evaluate', help="Evaluate warping mode. default: False", action='store_true', default=False
+    )
     args = parser.parse_args()
-    
-    output_dir = args.output
-    audio_path = args.audio
-    notes_path = args.notes
-    labels_path = args.labels
-    mode = args.mode
-    evaluate = args.evaluate
+    return args
 
-    align_notes_labels_audio(
-        audio_path, notes_path, labels_path, store=True, store_path=output_dir, verbose=False, visualize=False,
-        evaluate=evaluate, mode=mode
-        )
-    
 
-    
+def run():
+    """ Audio-to-annotations aligner """
+    args = parse_args()
+    main(
+        audio_path=args.audio,
+        notes_path=args.notes,
+        labels_path=args.labels,
+        store=True,
+        store_path=args.output,
+        verbose=False,
+        visualize=False,
+        evaluate=args.evaluate,
+        mode=args.mode
+    )
 
 if __name__ == '__main__':
-    main()
+    run()

--- a/aligner.py
+++ b/aligner.py
@@ -2,10 +2,9 @@
 import argparse
 from typing import Optional, Literal
 
+import ms3.cli
+
 from utils import align_notes_labels_audio
-
-
-# from ms3 import check_dir
 
 
 def main(
@@ -70,11 +69,8 @@ def parse_args():
     """
     )
     parser.add_argument('-a', '--audio', help='Path to audiofile', required=True)
-    # parser.add_argument('-p','--piece', help='Name of the desired piece from the Mozart corpus')
     parser.add_argument('-n', '--notes', help='Path to the notes TSV file', required=True)
     parser.add_argument('-l', '--labels', help='Path to the labels TSV file', required=False)
-    # parser.add_argument('-o', '--output', type=check_dir, default=os.path.join(os.getcwd(), 'alignment'),
-    # help='Folder for storing the alignment result. Can be relative, defaults to ./alignment')
     parser.add_argument(
         '-o', '--output',
         help='Folder for storing the alignment result. Can be relative, defaults to current working directory.'
@@ -88,6 +84,8 @@ def parse_args():
         '-e', '--evaluate', help="Evaluate warping mode. default: False", action='store_true', default=False
     )
     args = parser.parse_args()
+    if args.output:
+        args.output = ms3.cli.check_and_create(args.output)
     return args
 
 

--- a/aligner.py
+++ b/aligner.py
@@ -1,16 +1,17 @@
 # imports
 import argparse
+import os.path
 from typing import Optional, Literal
 
 import ms3.cli
+import pandas as pd
+from tqdm.auto import tqdm
 
 from utils import align_notes_labels_audio
 
 
-def main(
-        audio_path: str,
-        notes_path: str,
-        labels_path: Optional[str] = None,
+def batch_process(
+        csv_path: Optional[str] = None,
         store: bool = True,
         store_path: Optional[str] = None,
         verbose: bool = False,
@@ -18,17 +19,92 @@ def main(
         evaluate: bool = False,
         mode: Literal['compact', 'labels', 'extended'] = 'compact'
 ):
-    align_notes_labels_audio(
-        audio_path=audio_path,
-        notes_path=notes_path,
-        labels_path=labels_path,
-        store=store,
-        store_path=store_path,
-        verbose=verbose,
-        visualize=visualize,
-        evaluate=evaluate,
-        mode=mode
-    )
+    """
+
+    Args:
+        csv_path:
+            Path to a CSV file specifying paths for batch processing. The file needs to contain at
+            least the columns "audio" and "notes" and may come with an additional column "labels".
+            All values must be absolute paths or relative paths that resolve correctly for the
+            current working directory. If, in addition, you want to specify output filenames (with
+            or without .csv/.tsv extension), include them in a column called "name".
+        store:
+        store_path:
+        verbose:
+        visualize:
+        evaluate:
+        mode:
+    """
+    if store_path:
+        assert os.path.isdir(store_path), (f"store_path arg needs to be an existing directory for "
+                                               f"batch processing. Got {store_path!r}")
+    mapping = pd.read_csv(csv_path)
+    assert all(
+        col in mapping.columns
+        for col in ("audio", "notes")
+    ), (f"CSV file needs to have at least the columns "
+        f"'audio' and 'notes' containing file paths. The file "
+        f"{csv_path!r} comes with the "
+        f"columns {mapping.columns!r}.")
+    has_labels = "labels" in mapping.columns
+    has_names = "name" in mapping.columns
+    batch_size = len(mapping)
+    for row in tqdm(mapping.itertuples(), total=batch_size):
+        if has_names and not pd.isnull(row.name):
+            output_path = row.name
+            fname, ext = os.path.splitext(output_path)
+            if ext not in (".csv", ".tsv"):
+                output_path = fname + ".tsv"
+            if store_path:
+                output_path = os.path.join(store_path, output_path)
+        else:
+            output_path = store_path
+        align_notes_labels_audio(
+            audio_path=row.audio,
+            notes_path=row.notes,
+            labels_path=None if not has_labels else row.labels,
+            store=store,
+            store_path=output_path,
+            verbose=verbose,
+            visualize=visualize,
+            evaluate=evaluate,
+            mode=mode
+        )
+
+def main(
+        audio_path: Optional[str] = None,
+        notes_path: Optional[str] = None,
+        labels_path: Optional[str] = None,
+        csv_path: Optional[str] = None,
+        store: bool = True,
+        store_path: Optional[str] = None,
+        verbose: bool = False,
+        visualize: bool = False,
+        evaluate: bool = False,
+        mode: Literal['compact', 'labels', 'extended'] = 'compact'
+):
+    if csv_path:
+        batch_process(
+            csv_path=csv_path,
+            store=store,
+            store_path=store_path,
+            verbose=verbose,
+            visualize=visualize,
+            evaluate=evaluate,
+            mode=mode
+        )
+    else:
+        align_notes_labels_audio(
+            audio_path=audio_path,
+            notes_path=notes_path,
+            labels_path=labels_path,
+            store=store,
+            store_path=store_path,
+            verbose=verbose,
+            visualize=visualize,
+            evaluate=evaluate,
+            mode=mode
+        )
 
 
 def parse_args():
@@ -68,12 +144,21 @@ def parse_args():
         
     """
     )
-    parser.add_argument('-a', '--audio', help='Path to audiofile', required=True)
-    parser.add_argument('-n', '--notes', help='Path to the notes TSV file', required=True)
-    parser.add_argument('-l', '--labels', help='Path to the labels TSV file', required=False)
+    parser.add_argument(
+        '-c', '--csv',
+        help='Path to a CSV file specifying paths for batch processing. The file needs to contain at least the '
+             'columns "audio" and "notes" and may come with an additional column "labels". All values must be '
+             'absolute paths or relative paths that resolve correctly for the current working directory. If, '
+             'in addition, you want to specify output filenames (with or without .csv/.tsv extension), include '
+             'them in a column called "name"'
+             'When you specify this argument, -a, -n, and -l will be ignored.', )
+    parser.add_argument('-a', '--audio', help='Path to audiofile')
+    parser.add_argument('-n', '--notes', help='Path to the notes TSV file')
+    parser.add_argument('-l', '--labels', help='Path to the labels TSV file')
     parser.add_argument(
         '-o', '--output',
-        help='Folder for storing the alignment result. Can be relative, defaults to current working directory.'
+        help='Folder or filepath (.csv/.tsv) for storing the alignment result. Can be relative, defaults to current '
+             'working directory.'
     )
     parser.add_argument(
         '-m', '--mode',
@@ -84,8 +169,16 @@ def parse_args():
         '-e', '--evaluate', help="Evaluate warping mode. default: False", action='store_true', default=False
     )
     args = parser.parse_args()
-    if args.output:
-        args.output = ms3.cli.check_and_create(args.output)
+    if args.csv:
+        if args.output:
+            args.output = ms3.cli.check_and_create(args.output)
+        for arg in ("audio", "notes", "labels"):
+            if args.__dict__[arg]:
+                print(f"--{arg} is ignored when --csv is specified.")
+    else:
+        assert args.audio and args.notes, f"You need to either specify --csv or both --audio and --notes."
+        if args.output:
+            args.output = ms3.resolve_dir(args.output)
     return args
 
 
@@ -96,6 +189,7 @@ def run():
         audio_path=args.audio,
         notes_path=args.notes,
         labels_path=args.labels,
+        csv_path=args.csv,
         store=True,
         store_path=args.output,
         verbose=False,

--- a/examples/README.md
+++ b/examples/README.md
@@ -24,4 +24,15 @@ select the second movement, and export the audio to `K309-2_audio.wav` as shown 
 
 In the example directory, run the following command:
 
-    python ../aligner.py -a K309-2_audio.wav -n K309-2.notes.tsv -l K309-2.harmonies.tsv -o K309-2_aligned.csv 
+    python ../aligner.py -a K309-2_audio.wav -n K309-2.notes.tsv -l K309-2.harmonies.tsv -o K309-2_aligned.csv
+
+## Using batch conversion
+
+The file `batch.csv` contains an example for how you can achieve the same thing for several files at once.
+The paths can be absolute paths or, as in this example case, relative -- but you need to be sure that 
+they resolve correctly against your current working directory. In this example, the paths simply consists
+of files in the example folder, so, once again, we need to run the command in the examples folder:
+
+    python ../aligner.py -c batch.csv
+
+The output path in the "name" column, `../result.csv` is again relative and creates the result one level higher.

--- a/examples/batch.csv
+++ b/examples/batch.csv
@@ -1,0 +1,2 @@
+audio,notes,labels,name
+K309-2_audio.mp3,K309-2.notes.tsv,K309-2.harmonies.tsv,../result.csv

--- a/utils.py
+++ b/utils.py
@@ -2,6 +2,7 @@
 
 """ This module contains the main audio-to-annotations functionality and helper functions."""
 import os
+import warnings
 from typing import Optional, Literal
 
 import librosa.display
@@ -158,42 +159,75 @@ def align_warped_notes_labels(df_annotation_warped, notes_labels_extended, mode=
         aligned_timestamps_labels: DataFrame object
             Labels and optional information, aligned with timestamps
     """
-    
+    # the following columns are included on both sides and will be dropped on one
+    duplicate_columns = ['start', 'end', 'mc_playthrough', 'mn_playthrough', 'quarterbeats_all_endings']
+
     if mode == 'compact':
-        aligned_timestamps_labels = pd.merge(df_annotation_warped.drop(columns= ['velocity',
-                                                                                'instrument', 
-                                                                                'duration',
-                                                                                'pitch',
-                                                                                'end']),
-                                            notes_labels_extended[['label']], right_index=True, left_index=True)
-        aligned_timestamps_labels = aligned_timestamps_labels.dropna(subset='label').drop_duplicates(subset = ['start', 'label'])
-        
+        aligned_timestamps_labels = pd.merge(
+            left=df_annotation_warped.drop(
+                columns=[
+                    'velocity',
+                    'instrument',
+                    'duration',
+                    'pitch',
+                    'end'
+                ]
+            ),
+            how="outer",
+            right=notes_labels_extended[['label']],
+            right_index=True,
+            left_index=True
+        )
+        aligned_timestamps_labels = aligned_timestamps_labels.dropna(subset='label').drop_duplicates(
+            subset=['start', 'label']
+        )
+
     elif mode == 'labels':
-        
-        notes_related_columns = ['staff','voice', 'duration', 'nominal_duration', 'scalar',
-                                 'tied','tpc', 'midi', 'chord_id']
-        
-        # Note: additional columns not present in all pieces could be also added and tested here
-        if 'gracenote' in notes_labels_extended:
-            notes_related_columns.append('gracenote')
-    
-        aligned_timestamps_labels = pd.merge(df_annotation_warped.drop(columns=['velocity',
-                                                                                'instrument',
-                                                                                'pitch']).rename(
-            columns={'duration':'duration_time'}),
-                                            notes_labels_extended.drop(columns=notes_related_columns),
-                                            right_index=True, left_index=True)
-        aligned_timestamps_labels = aligned_timestamps_labels.dropna(subset='label').drop_duplicates(subset = ['start', 'label'])
+
+        notes_related_columns = ['staff', 'voice', 'duration', 'nominal_duration', 'scalar', 'gracenote'
+                                                                                             'tied', 'tpc', 'midi',
+                                 'chord_id', ]
+
+        drop_cols = [col for col in notes_related_columns + duplicate_columns if col in notes_labels_extended.columns]
+        aligned_timestamps_labels = pd.merge(
+            left=df_annotation_warped.drop(
+                columns=[
+                    'velocity',
+                    'instrument',
+                    'pitch'
+                ]
+            ).rename(
+                columns={'duration': 'duration_time'}
+            ),
+            right=notes_labels_extended.drop(columns=drop_cols),
+            how="outer",
+            right_index=True,
+            left_index=True
+        )
+        aligned_timestamps_labels = aligned_timestamps_labels.dropna(subset='label').drop_duplicates(
+            subset=['start', 'label']
+        )
 
     elif mode == 'extended':
-        aligned_timestamps_labels = pd.merge(df_annotation_warped.drop(columns=['velocity',
-                                                                                'instrument',
-                                                                                'pitch']).rename(
-            columns={'duration':'duration_time'}),
-                                            notes_labels_extended, right_index=True, left_index=True)
-    
+        drop_cols = [col for col in duplicate_columns if col in notes_labels_extended.columns]
+        aligned_timestamps_labels = pd.merge(
+            left=df_annotation_warped.drop(
+                columns=[
+                    'velocity',
+                    'instrument',
+                    'pitch'
+                ]
+            ).rename(
+                columns={'duration': 'duration_time'}
+            ),
+            right=notes_labels_extended.drop(columns=drop_cols),
+            how="outer",
+            right_index=True,
+            left_index=True
+        )
+
     else:
-        raise ValueError("'mode' parameter should take either 'compact', 'labels' or 'extended' value")
+        raise ValueError(f"'mode' parameter should bei either 'compact', 'labels' or 'extended', got {mode}")
     
     aligned_timestamps_labels = aligned_timestamps_labels.rename(columns={'start':'timestamp'})
     
@@ -375,13 +409,17 @@ def align_notes_labels_audio(
             Defaults to False.
         evaluate: bool (optional)
             Prints DTW matching score. Defaults to False.
-        mode: str (optional)
-            Level of details the result should keep. 
-            Can take value between: ['compact', 'labels', 'extended']
-                Compact: only outputs labels aligned with timestamps
-                Labels details: outputs labels and additional label information aligned with timestamps
-                Extended: outputs merged notes and labels datasets with additional information, aligned with timestamps                
-            Defaults to 'compact'.
+        mode: str (default: 'compact')
+            compact:
+                - without labels: columns ["start", "end", "pitch"]
+                - with labels: columns ["timestamp", "label"]
+            extended:
+                - without labels: fully aligned original notes TSV
+                - with labels: fully aligned original notes TSV with original label columns merged
+            labels:
+                Original label columns preceded by columns ["timestamp", "duration_time", "end"].
+                Please note that the durations and end points to not currently reflect those of the
+                labels but those of one of the notes they co-occur with.
 
     Returns:
         result: DataFrame object
@@ -413,12 +451,10 @@ def align_notes_labels_audio(
     if labels_path:
         df_annotation_extended = align_corpus_notes_and_labels(notes_path, labels_path)
     else:
+        df_annotation_extended = None
         if mode == "labels":
             raise ValueError("When 'mode' is set to 'labels', labels_path must be provided")
-        if mode == "compact":
-            mode = "notes"
-        elif mode == "extended":
-            mode = "scofo"
+
     
     # Load audio
     audio, _ = librosa.load(audio_path, sr=Fs)
@@ -468,15 +504,24 @@ def align_notes_labels_audio(
     
     # Align time-aligned annotations of notes with labels
     result = df_annotation_warped
-    if mode in ['compact', 'labels', 'extended']:
+    if df_annotation_extended is not None:
         result = align_warped_notes_labels(df_annotation_warped, df_annotation_extended, mode)
-    elif mode == 'notes':
+    elif mode == 'compact':
         result = result[['start', 'end', 'pitch']]
-    elif mode == 'scofo':
+    elif mode == 'extended':
         # Return notes and their temporal positions, and additional information from the notes dataset
         notes_df = pd.read_csv(notes_path, sep='\t', dtype="string") # loading as nullable strings to not change any data
+
+        if "start" in notes_df.columns:
+            warnings.warn(
+                f"The notes TSV already came with a 'start' column, so the result has two of them. If you want to add "
+                f"alignments for several recordings to the same note tables, it is a good idea to rename the columns "
+                f"accordingly."
+            )
         assert notes_df.midi.equals(df_annotation_warped.pitch.astype("string")), "MIDI values do not match"
         result = pd.concat([notes_df, df_annotation_warped[['start', 'end']]], axis=1)
+    else:
+        raise ValueError(f"'mode' parameter should bei either 'compact', 'labels' or 'extended', got {mode}")
 
     
     # Store

--- a/utils.py
+++ b/utils.py
@@ -1,31 +1,27 @@
 ###################################################################
 
 """ This module contains the main audio-to-annotations functionality and helper functions."""
+import os
+from typing import Optional, Literal
 
-############################# IMPORTS #############################
-
-from libfmp.b import list_to_pitch_activations, plot_chromagram, plot_signal, plot_matrix, \
-                     sonify_pitch_activations_with_signal
 import librosa.display
+import ms3
 import numpy as np
 import pandas as pd
 import scipy.interpolate
-
-#import sys
-#sys.path.insert(0, '../sync_toolbox/synctoolbox/')
+from libfmp.b import plot_chromagram
+# import sys
+# sys.path.insert(0, '../sync_toolbox/synctoolbox/')
 from synctoolbox.dtw.mrmsdtw import sync_via_mrmsdtw
 from synctoolbox.dtw.utils import compute_optimal_chroma_shift, shift_chroma_vectors, make_path_strictly_monotonic
-from synctoolbox.feature.csv_tools import read_csv_to_df, df_to_pitch_features, df_to_pitch_onset_features
 from synctoolbox.feature.chroma import pitch_to_chroma, quantize_chroma, quantized_chroma_to_CENS
+from synctoolbox.feature.csv_tools import df_to_pitch_features, df_to_pitch_onset_features
 from synctoolbox.feature.dlnco import pitch_onset_features_to_DLNCO
 from synctoolbox.feature.pitch import audio_to_pitch_features
 from synctoolbox.feature.pitch_onset import audio_to_pitch_onset_features
 from synctoolbox.feature.utils import estimate_tuning
 
-import ms3
-import libfmp.c2
-import os
-
+############################# IMPORTS #############################
 
 
 ############################# GLOBALS #############################
@@ -339,15 +335,15 @@ def evaluate_matching(df_original_notes, df_warped_notes, verbose=True):
 
 
 def align_notes_labels_audio(
-        audio_path,
-        notes_path,
-        labels_path=None,
-        store=True,
-        store_path=None,
-        verbose=False,
-        visualize=False,
-        evaluate=False,
-        mode='compact'
+        audio_path: str,
+        notes_path: str,
+        labels_path: Optional[str] = None,
+        store: bool = True,
+        store_path: Optional[str] = None,
+        verbose: bool = False,
+        visualize: bool = False,
+        evaluate: bool = False,
+        mode: Literal['compact', 'labels', 'extended'] = 'compact'
         ):
     """This function performs the whole pipeline of aligning an audio recording of a piece and its
     corresponding labels annotations from DCML's Mozart sonatas corpus [1], using synctoolbox dynamic


### PR DESCRIPTION
This PR

* streamlines the three modes `"compact", "extended", "labels"` for the two cases that labels are given or not
* adds the `-c/--csv` argument to allow for batch processing and adds an example